### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "chmod +x gradlew && ./gradlew && ./gradlew run"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Check down below for a screenshot.
 ## Releases
 
 [![Build Status](https://dev.azure.com/brunocborges/fx2048/_apis/build/status/brunoborges.fx2048?branchName=master)](https://dev.azure.com/brunocborges/fx2048/_build/latest?definitionId=1&branchName=master)
+[![run on repl.it](http://repl.it/badge/github/brunoborges/fx2048)](https://repl.it/github/brunoborges/fx2048)
 
 You may find binaries available for download, for Windows, Mac and Linux, with Java bundled in (using Java 11 jlink custom images). The ZIP files come with a binary that will start the game with the bundled optimized/trimmed JVM with only the needed modules, making the binaries extremely small comparably with the normal JRE download size. 
 


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-fx2048):

![image](https://i.imgur.com/85oUDsC.png)
