### PR TITLE
Add game model tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
         <maven.compiler.release>25</maven.compiler.release>
         <javafx.version>25.0.3</javafx.version>
         <javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
+        <junit.jupiter.version>5.11.4</junit.jupiter.version>
+        <maven.surefire.plugin.version>3.5.3</maven.surefire.plugin.version>
         <main.class>io.fxgame.game2048.AppLauncher</main.class>
     </properties>
 
@@ -36,6 +38,12 @@
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
             <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -137,6 +145,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>3.5.0</version>
+            </plugin>
+
+            <!-- Maven Surefire Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
             </plugin>
 
             <!-- Maven Enforcer Plugin -->

--- a/src/main/java/io/fxgame/game2048/Board.java
+++ b/src/main/java/io/fxgame/game2048/Board.java
@@ -588,9 +588,9 @@ public class Board extends Pane {
     /*
      * Once we have confirmation
      */
-    public void saveSession(Map<Location, Tile> gameGrid) {
+    public void saveSession(Map<Location, Integer> gridValues) {
         state.saveGame.set(false);
-        if (sessionManager.saveSession(gameGrid, state.gameScoreProperty.getValue(),
+        if (sessionManager.saveSession(gridValues, state.gameScoreProperty.getValue(),
                 LocalTime.now().minusNanos(time.toNanoOfDay()).toNanoOfDay(), state.gameMoveCountProperty.getValue())) {
             keepGoing();
         } else {
@@ -607,7 +607,7 @@ public class Board extends Pane {
     /*
      * Once we have confirmation
      */
-    public boolean restoreSession(Map<Location, Tile> gameGrid) {
+    public boolean restoreSession(Map<Location, Integer> gridValues) {
         state.restoreGame.set(false);
         var restoredSession = sessionManager.restoreSession();
         if (restoredSession.isEmpty()) {
@@ -617,14 +617,14 @@ public class Board extends Pane {
 
         doClearGame();
         timer.stop();
-        gameGrid.clear();
-        gameGrid.putAll(restoredSession.get().gameGrid());
+        gridValues.clear();
+        gridValues.putAll(restoredSession.get().gridValues());
         state.gameScoreProperty.set(restoredSession.get().score());
         state.gameMoveCountProperty.set(restoredSession.get().moveCount());
         // check tiles>=2048
         state.gameWonProperty.set(false);
-        gameGrid.forEach((_, t) -> {
-            if (t != null && t.getValue() >= GameManager.FINAL_VALUE_TO_WIN) {
+        gridValues.forEach((_, value) -> {
+            if (value >= GameManager.FINAL_VALUE_TO_WIN) {
                 state.gameWonProperty.removeListener(wonListener);
                 state.gameWonProperty.set(true);
                 state.gameWonProperty.addListener(wonListener);

--- a/src/main/java/io/fxgame/game2048/GameManager.java
+++ b/src/main/java/io/fxgame/game2048/GameManager.java
@@ -392,7 +392,7 @@ public class GameManager extends Group {
      * Save the game to a properties file, without confirmation.
      */
     private void doSaveSession() {
-        board.saveSession(gameGrid);
+        board.saveSession(model.snapshot());
     }
 
     /**
@@ -406,17 +406,13 @@ public class GameManager extends Group {
      * Restore the game from a properties file, without confirmation.
      */
     private void doRestoreSession() {
-        if (board.restoreSession(gameGrid)) {
-            model.restoreSnapshot(tileValues(gameGrid));
+        var restoredValues = new HashMap<Location, Integer>();
+        if (board.restoreSession(restoredValues)) {
+            model.restoreSnapshot(restoredValues);
+            syncTileMapFromModel();
             redrawTilesInGameGrid();
             undoSnapshot = null;
         }
-    }
-
-    private Map<Location, Integer> tileValues(Map<Location, Tile> tiles) {
-        var values = new HashMap<Location, Integer>();
-        tiles.forEach((location, tile) -> values.put(location, tile == null ? 0 : tile.getValue()));
-        return values;
     }
 
     /**

--- a/src/main/java/io/fxgame/game2048/SessionManager.java
+++ b/src/main/java/io/fxgame/game2048/SessionManager.java
@@ -18,18 +18,18 @@ public class SessionManager {
     private final Properties props = new Properties();
     private final GridOperator gridOperator;
 
-    protected record SessionData(Map<Location, Tile> gameGrid, int score, long time, int moveCount) {}
+    protected record SessionData(Map<Location, Integer> gridValues, int score, long time, int moveCount) {}
 
     public SessionManager(GridOperator gridOperator) {
         this.gridOperator = gridOperator;
         this.propertiesFilename = "game2048_" + gridOperator.getGridSize() + ".properties";
     }
 
-    protected boolean saveSession(Map<Location, Tile> gameGrid, Integer score, Long time, Integer moveCount) {
+    protected boolean saveSession(Map<Location, Integer> gridValues, Integer score, Long time, Integer moveCount) {
         props.clear();
         gridOperator.traverseGrid((x, y) -> {
-            var tile = gameGrid.get(new Location(x, y));
-            props.setProperty("Location_" + x + "_" + y, tile != null ? tile.getValue().toString() : "0");
+            var tileValue = gridValues.get(new Location(x, y));
+            props.setProperty("Location_" + x + "_" + y, Integer.toString(tileValue == null ? 0 : tileValue));
             return 0;
         });
         props.setProperty("score", score.toString());
@@ -45,17 +45,15 @@ public class SessionManager {
         }
 
         try {
-            var restoredGrid = new HashMap<Location, Tile>();
+            var restoredValues = new HashMap<Location, Integer>();
             gridOperator.traverseGrid((x, y) -> {
                 var val = requireProperty("Location_" + x + "_" + y);
                 var tileValue = Integer.parseInt(val);
                 var location = new Location(x, y);
-                restoredGrid.put(location, null);
+                restoredValues.put(location, 0);
                 if (tileValue != 0) {
                     validateTileValue(tileValue);
-                    var tile = Tile.newTile(tileValue);
-                    tile.setLocation(location);
-                    restoredGrid.put(location, tile);
+                    restoredValues.put(location, tileValue);
                 }
                 return 0;
             });
@@ -64,7 +62,7 @@ public class SessionManager {
             var time = parseNonNegativeLong(requireProperty("time"), "time");
             var moveCount = parseNonNegativeInt(props.getProperty("moves", "0"), "moves");
 
-            return Optional.of(new SessionData(restoredGrid, score, time, moveCount));
+            return Optional.of(new SessionData(restoredValues, score, time, moveCount));
         } catch (IllegalArgumentException e) {
             LOGGER.log(Level.WARNING, "Invalid saved session: " + propertiesFilename, e);
             return Optional.empty();

--- a/src/test/java/io/fxgame/game2048/GameModelTest.java
+++ b/src/test/java/io/fxgame/game2048/GameModelTest.java
@@ -1,0 +1,146 @@
+package io.fxgame.game2048;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+class GameModelTest {
+
+    @Test
+    void moveLeftMergesAdjacentTilesAndTracksScore() {
+        var model = modelWith(
+                row(2, 2, 2, 0),
+                row(0, 0, 0, 0),
+                row(0, 0, 0, 0),
+                row(0, 0, 0, 0));
+
+        var result = model.move(Direction.LEFT);
+
+        assertTrue(result.tilesMoved());
+        assertEquals(4, result.points());
+        assertFalse(result.won());
+        assertRow(model, 0, 4, 2, 0, 0);
+    }
+
+    @Test
+    void moveLeftOnlyMergesEachDestinationOnce() {
+        var model = modelWith(
+                row(2, 2, 2, 2),
+                row(0, 0, 0, 0),
+                row(0, 0, 0, 0),
+                row(0, 0, 0, 0));
+
+        var result = model.move(Direction.LEFT);
+
+        assertTrue(result.tilesMoved());
+        assertEquals(8, result.points());
+        assertRow(model, 0, 4, 4, 0, 0);
+    }
+
+    @Test
+    void moveRightSlidesTilesToFarthestAvailableLocation() {
+        var model = modelWith(
+                row(2, 0, 0, 0),
+                row(0, 0, 0, 0),
+                row(0, 0, 0, 0),
+                row(0, 0, 0, 0));
+
+        var result = model.move(Direction.RIGHT);
+
+        assertTrue(result.tilesMoved());
+        assertEquals(0, result.points());
+        assertRow(model, 0, 0, 0, 0, 2);
+    }
+
+    @Test
+    void moveReportsWinningMerge() {
+        var model = modelWith(
+                row(1024, 1024, 0, 0),
+                row(0, 0, 0, 0),
+                row(0, 0, 0, 0),
+                row(0, 0, 0, 0));
+
+        var result = model.move(Direction.LEFT);
+
+        assertTrue(result.won());
+        assertEquals(2048, result.points());
+        assertRow(model, 0, 2048, 0, 0, 0);
+    }
+
+    @Test
+    void fullBoardWithoutPairsHasNoAvailableMergeMovements() {
+        var model = modelWith(
+                row(2, 4, 2, 4),
+                row(4, 2, 4, 2),
+                row(2, 4, 2, 4),
+                row(4, 2, 4, 2));
+
+        var result = model.move(Direction.LEFT);
+
+        assertFalse(result.tilesMoved());
+        assertTrue(model.isFull());
+        assertFalse(model.hasMergeMovements());
+    }
+
+    @Test
+    void fullBoardWithAdjacentPairHasMergeMovements() {
+        var model = modelWith(
+                row(2, 2, 4, 8),
+                row(16, 32, 64, 128),
+                row(256, 512, 1024, 2048),
+                row(4096, 8192, 16384, 32768));
+
+        assertTrue(model.isFull());
+        assertTrue(model.hasMergeMovements());
+    }
+
+    @Test
+    void addRandomTileFillsAnAvailableLocation() {
+        var model = modelWith(
+                row(2, 4, 2, 4),
+                row(4, 2, 4, 2),
+                row(2, 4, 2, 4),
+                row(4, 2, 4, 0));
+
+        var addedTile = model.addRandomTile();
+
+        assertTrue(addedTile.isPresent());
+        assertEquals(new Location(3, 3), addedTile.get().location());
+        assertTrue(addedTile.get().value() == 2 || addedTile.get().value() == 4);
+        assertTrue(model.isFull());
+    }
+
+    private GameModel modelWith(int[]... rows) {
+        var model = new GameModel(new GridOperator(4), new Random(0));
+        model.restoreSnapshot(snapshot(rows));
+        return model;
+    }
+
+    private Map<Location, Integer> snapshot(int[]... rows) {
+        var snapshot = new HashMap<Location, Integer>();
+        for (int y = 0; y < rows.length; y++) {
+            for (int x = 0; x < rows[y].length; x++) {
+                snapshot.put(new Location(x, y), rows[y][x]);
+            }
+        }
+        return snapshot;
+    }
+
+    private int[] row(int value0, int value1, int value2, int value3) {
+        return new int[] { value0, value1, value2, value3 };
+    }
+
+    private void assertRow(GameModel model, int y, int value0, int value1, int value2, int value3) {
+        var snapshot = model.snapshot();
+        assertEquals(value0, snapshot.get(new Location(0, y)));
+        assertEquals(value1, snapshot.get(new Location(1, y)));
+        assertEquals(value2, snapshot.get(new Location(2, y)));
+        assertEquals(value3, snapshot.get(new Location(3, y)));
+    }
+}


### PR DESCRIPTION
## Summary
- Add JUnit 5 and Surefire test support
- Cover GameModel moves, merges, scoring, win detection, merge availability, and random tile insertion
- Decouple session persistence from JavaFX Tile by saving/restoring Map<Location, Integer> model snapshots

## Validation
- ./mvnw test
- ./mvnw -q clean package javafx:jlink jpackage:jpackage