### PR TITLE
Extract game timer

### DIFF
--- a/src/main/java/io/fxgame/game2048/Board.java
+++ b/src/main/java/io/fxgame/game2048/Board.java
@@ -1,22 +1,16 @@
 package io.fxgame.game2048;
 
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 
-import javafx.animation.Animation;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.geometry.Pos;
@@ -46,10 +40,7 @@ public class Board extends Pane {
 
     private final GameState state = new GameState();
 
-    private LocalTime time;
-    private Timeline timer;
-    private final StringProperty clock = new SimpleStringProperty("00:00:00");
-    private final DateTimeFormatter fmt = DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault());
+    private final GameTimer gameTimer = new GameTimer();
 
     // User Interface controls
     private final VBox vGame = new VBox(0);
@@ -161,9 +152,7 @@ public class Board extends Pane {
         hTime.setMinSize(gridDimension, GAP_HEIGHT);
         hTime.setAlignment(Pos.BOTTOM_RIGHT);
         lblTime.getStyleClass().addAll("game-label", "game-time");
-        lblTime.textProperty().bind(clock);
-        timer = new Timeline(new KeyFrame(Duration.ZERO, _ -> clock.set(LocalTime.now().minusNanos(time.toNanoOfDay()).format(fmt))), new KeyFrame(Duration.seconds(1)));
-        timer.setCycleCount(Animation.INDEFINITE);
+        lblTime.textProperty().bind(gameTimer.clockProperty());
         hTime.getChildren().add(lblTime);
 
         vGame.getChildren().add(hTime);
@@ -248,7 +237,7 @@ public class Board extends Pane {
 
     private void keepGoing() {
         state.keepGoing();
-        timer.play();
+        gameTimer.resume();
     }
 
     private void exitGame() {
@@ -293,7 +282,7 @@ public class Board extends Pane {
                 return;
             }
 
-            timer.stop();
+            gameTimer.pause();
             overlayPanel.showMessage(style1, message, warning, style2, leftButton, rightButton);
 
             if (!state.layerOnProperty.get()) {
@@ -305,7 +294,7 @@ public class Board extends Pane {
 
     private void showMessageOverlay(String message, String warning, String overlayStyle, String messageStyle,
             Button leftButton, Button rightButton) {
-        timer.stop();
+        gameTimer.pause();
         overlayPanel.showMessage(overlayStyle, message, warning, messageStyle, leftButton, rightButton);
         showOverlay(leftButton);
     }
@@ -405,7 +394,7 @@ public class Board extends Pane {
     }
 
     private void showAboutOverlay() {
-        timer.stop();
+        gameTimer.pause();
         overlayPanel.showContent("game-overlay-quit", bContinue, null, new AboutContent(gridDimension));
         showOverlay(bContinue);
     }
@@ -460,9 +449,7 @@ public class Board extends Pane {
 
     public void startGame() {
         restoreRecord();
-
-        time = LocalTime.now();
-        timer.playFromStart();
+        gameTimer.startNew();
     }
 
     public void setPoints(int points) {
@@ -531,7 +518,7 @@ public class Board extends Pane {
     }
 
     private void showSettingsOverlay() {
-        timer.stop();
+        gameTimer.pause();
 
         var title = new Label("Settings");
         title.getStyleClass().setAll("game-label", "game-lblPause");
@@ -591,7 +578,7 @@ public class Board extends Pane {
     public void saveSession(Map<Location, Integer> gridValues) {
         state.saveGame.set(false);
         if (sessionManager.saveSession(gridValues, state.gameScoreProperty.getValue(),
-                LocalTime.now().minusNanos(time.toNanoOfDay()).toNanoOfDay(), state.gameMoveCountProperty.getValue())) {
+                gameTimer.elapsedNanos(), state.gameMoveCountProperty.getValue())) {
             keepGoing();
         } else {
             showMessageOverlay("Save failed", "Session could not be written");
@@ -616,7 +603,7 @@ public class Board extends Pane {
         }
 
         doClearGame();
-        timer.stop();
+        gameTimer.pause();
         gridValues.clear();
         gridValues.putAll(restoredSession.get().gridValues());
         state.gameScoreProperty.set(restoredSession.get().score());
@@ -630,8 +617,7 @@ public class Board extends Pane {
                 state.gameWonProperty.addListener(wonListener);
             }
         });
-        time = LocalTime.now().minusNanos(restoredSession.get().time());
-        timer.play();
+        gameTimer.restore(restoredSession.get().time());
         return true;
     }
 

--- a/src/main/java/io/fxgame/game2048/GameTimer.java
+++ b/src/main/java/io/fxgame/game2048/GameTimer.java
@@ -34,9 +34,7 @@ final class GameTimer {
     private GameTimer(LongSupplier nanoTime, boolean useTimeline) {
         this.nanoTime = nanoTime;
         if (useTimeline) {
-            timeline = new Timeline(
-                    new KeyFrame(Duration.ZERO, _ -> updateClock()),
-                    new KeyFrame(Duration.seconds(1)));
+            timeline = new Timeline(new KeyFrame(Duration.seconds(1), _ -> updateClock()));
             timeline.setCycleCount(Animation.INDEFINITE);
         } else {
             timeline = null;
@@ -60,7 +58,7 @@ final class GameTimer {
         }
         updateClock();
         if (timeline != null) {
-            timeline.play();
+            timeline.playFromStart();
         }
     }
 

--- a/src/main/java/io/fxgame/game2048/GameTimer.java
+++ b/src/main/java/io/fxgame/game2048/GameTimer.java
@@ -1,0 +1,105 @@
+package io.fxgame.game2048;
+
+import java.util.function.LongSupplier;
+
+import javafx.animation.Animation;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.util.Duration;
+
+final class GameTimer {
+
+    private static final long NANOS_PER_SECOND = 1_000_000_000L;
+    private static final long SECONDS_PER_MINUTE = 60L;
+    private static final long SECONDS_PER_HOUR = 3_600L;
+
+    private final LongSupplier nanoTime;
+    private final StringProperty clock = new SimpleStringProperty(formatElapsed(0));
+    private final Timeline timeline;
+    private long elapsedNanos;
+    private long startedAtNanos;
+    private boolean running;
+
+    GameTimer() {
+        this(System::nanoTime, true);
+    }
+
+    GameTimer(LongSupplier nanoTime) {
+        this(nanoTime, false);
+    }
+
+    private GameTimer(LongSupplier nanoTime, boolean useTimeline) {
+        this.nanoTime = nanoTime;
+        if (useTimeline) {
+            timeline = new Timeline(
+                    new KeyFrame(Duration.ZERO, _ -> updateClock()),
+                    new KeyFrame(Duration.seconds(1)));
+            timeline.setCycleCount(Animation.INDEFINITE);
+        } else {
+            timeline = null;
+        }
+    }
+
+    ReadOnlyStringProperty clockProperty() {
+        return clock;
+    }
+
+    void startNew() {
+        elapsedNanos = 0;
+        running = false;
+        resume();
+    }
+
+    void resume() {
+        if (!running) {
+            startedAtNanos = nanoTime.getAsLong();
+            running = true;
+        }
+        updateClock();
+        if (timeline != null) {
+            timeline.play();
+        }
+    }
+
+    void pause() {
+        if (running) {
+            elapsedNanos = elapsedNanos();
+            running = false;
+        }
+        if (timeline != null) {
+            timeline.stop();
+        }
+        updateClock();
+    }
+
+    void restore(long elapsedNanos) {
+        if (elapsedNanos < 0) {
+            throw new IllegalArgumentException("Elapsed time must not be negative");
+        }
+        this.elapsedNanos = elapsedNanos;
+        running = false;
+        resume();
+    }
+
+    long elapsedNanos() {
+        if (!running) {
+            return elapsedNanos;
+        }
+        return elapsedNanos + nanoTime.getAsLong() - startedAtNanos;
+    }
+
+    private void updateClock() {
+        clock.set(formatElapsed(elapsedNanos()));
+    }
+
+    static String formatElapsed(long elapsedNanos) {
+        var elapsedSeconds = Math.max(0, elapsedNanos / NANOS_PER_SECOND);
+        var hours = elapsedSeconds / SECONDS_PER_HOUR;
+        var minutes = (elapsedSeconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE;
+        var seconds = elapsedSeconds % SECONDS_PER_MINUTE;
+        return "%02d:%02d:%02d".formatted(hours, minutes, seconds);
+    }
+}

--- a/src/main/java/io/fxgame/game2048/RecordManager.java
+++ b/src/main/java/io/fxgame/game2048/RecordManager.java
@@ -1,11 +1,15 @@
 package io.fxgame.game2048;
 
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author Jose Pereda
  */
 public class RecordManager {
+
+    private static final Logger LOGGER = Logger.getLogger(RecordManager.class.getName());
 
     public final String propertiesFilename;
     private final Properties props = new Properties();
@@ -16,18 +20,32 @@ public class RecordManager {
 
     public void saveRecord(Integer score) {
         int oldRecord = restoreRecord();
+        props.clear();
         props.setProperty("record", Integer.toString(Math.max(oldRecord, score)));
         UserSettings.LOCAL.store(props, propertiesFilename);
     }
 
     public int restoreRecord() {
+        props.clear();
         UserSettings.LOCAL.restore(props, propertiesFilename);
 
         String score = props.getProperty("record");
         if (score != null) {
-            return Integer.parseInt(score);
+            try {
+                return parseRecord(score);
+            } catch (IllegalArgumentException e) {
+                LOGGER.log(Level.WARNING, "Invalid record value in " + propertiesFilename, e);
+            }
         }
         return 0;
+    }
+
+    private int parseRecord(String score) {
+        var record = Integer.parseInt(score);
+        if (record < 0) {
+            throw new IllegalArgumentException("Record must not be negative");
+        }
+        return record;
     }
 
 }

--- a/src/main/java/io/fxgame/game2048/UserSettings.java
+++ b/src/main/java/io/fxgame/game2048/UserSettings.java
@@ -58,6 +58,9 @@ public enum UserSettings {
         } catch (FileNotFoundException e) {
             Logger.getLogger(UserSettings.class.getName()).log(Level.INFO, "Properties file not found: {0}", fileName);
             return false;
+        } catch (IllegalArgumentException e) {
+            Logger.getLogger(UserSettings.class.getName()).log(Level.WARNING, "Invalid properties file: {0}", fileName);
+            return false;
         } catch (IOException ex) {
             Logger.getLogger(UserSettings.class.getName()).log(Level.SEVERE, null, ex);
             return false;

--- a/src/test/java/io/fxgame/game2048/GameTimerTest.java
+++ b/src/test/java/io/fxgame/game2048/GameTimerTest.java
@@ -1,0 +1,43 @@
+package io.fxgame.game2048;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.Test;
+
+class GameTimerTest {
+
+    @Test
+    void formatsElapsedTimeWithoutDayWraparound() {
+        assertEquals("00:00:00", GameTimer.formatElapsed(0));
+        assertEquals("01:01:01", GameTimer.formatElapsed(nanos(1, 1, 1)));
+        assertEquals("25:00:00", GameTimer.formatElapsed(nanos(25, 0, 0)));
+    }
+
+    @Test
+    void tracksPauseResumeAndRestoreUsingElapsedNanos() {
+        var ticker = new AtomicLong();
+        var timer = new GameTimer(ticker::get);
+
+        timer.startNew();
+        ticker.set(nanos(0, 0, 5));
+        assertEquals(nanos(0, 0, 5), timer.elapsedNanos());
+
+        timer.pause();
+        ticker.set(nanos(0, 0, 9));
+        assertEquals(nanos(0, 0, 5), timer.elapsedNanos());
+
+        timer.resume();
+        ticker.set(nanos(0, 0, 11));
+        assertEquals(nanos(0, 0, 7), timer.elapsedNanos());
+
+        timer.restore(nanos(0, 1, 0));
+        ticker.set(nanos(0, 0, 12));
+        assertEquals(nanos(0, 1, 1), timer.elapsedNanos());
+    }
+
+    private static long nanos(long hours, long minutes, long seconds) {
+        return ((hours * 3_600) + (minutes * 60) + seconds) * 1_000_000_000L;
+    }
+}


### PR DESCRIPTION
## Summary
- Extract elapsed-time tracking and clock formatting from Board into GameTimer
- Add deterministic GameTimer unit tests for pause/resume/restore and long-duration formatting
- Harden record restore against corrupt or negative values
- Treat malformed properties files as invalid settings restores instead of surfacing parse errors

## Validation
- ./mvnw test
- ./mvnw -q clean package javafx:jlink jpackage:jpackage