### PR TITLE
Set default max heap to 48 MB

### DIFF
--- a/MAVEN.md
+++ b/MAVEN.md
@@ -23,7 +23,7 @@ The project includes a Maven wrapper (`mvnw`) that ensures everyone uses the sam
 ./mvnw javafx:run
 ```
 
-The Maven and packaged launchers default to `-Xmx32m -XX:+UseZGC`.
+The Maven and packaged launchers default to `-Xmx48m -XX:+UseZGC`.
 
 #### Package the application
 ```bash

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Maven is the build system used by CI; use the included Maven wrapper:
 ./mvnw javafx:run
 ```
 
-The application is launched with a maximum 32 MB heap and ZGC by default.
+The application is launched with a maximum 48 MB heap and ZGC by default.
 
 ### Create a distribution to your operating system (Windows, Linux, or Mac OS)
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <junit.jupiter.version>5.11.4</junit.jupiter.version>
         <maven.surefire.plugin.version>3.5.3</maven.surefire.plugin.version>
         <main.class>io.fxgame.game2048.AppLauncher</main.class>
-        <runtime.max.heap>-Xmx32m</runtime.max.heap>
+        <runtime.max.heap>-Xmx48m</runtime.max.heap>
         <runtime.garbage.collector>-XX:+UseZGC</runtime.garbage.collector>
     </properties>
 


### PR DESCRIPTION
## Summary
- Change the default runtime max heap from 32 MB to 48 MB
- Keep ZGC enabled by default for Maven and packaged launchers
- Update README and Maven docs

## Validation
- ./mvnw test
- ./mvnw -q clean package javafx:jlink jpackage:jpackage