### PR TITLE
Add macOS JVM entitlements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@
                             <macSign>true</macSign>
                             <macSigningKeychain>${mac.signing.keychain}</macSigningKeychain>
                             <macSigningKeyUserName>${mac.signing.key.user.name}</macSigningKeyUserName>
+                            <macEntitlements>src/jpackage/fx2048.entitlements</macEntitlements>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/jpackage/fx2048.entitlements
+++ b/src/jpackage/fx2048.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Add macOS hardened-runtime entitlements required by the bundled JVM/JIT.
- Wire the entitlements plist into the mac-signing jpackage profile.

## Why
The notarized 1.0.4 macOS app crashes during JVM startup in pthread_jit_write_protect_np, which indicates the signed app is missing JIT/executable-memory entitlements under hardened runtime.

## Validation
- plutil -lint src/jpackage/fx2048.entitlements
- ./mvnw test
- ./mvnw -q clean package javafx:jlink jpackage:jpackage
- ./mvnw -Pmac-signing help:effective-pom confirms macEntitlements is configured
