### PR TITLE
Update download-artifact action to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,7 +398,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download package artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: release-assets
           merge-multiple: true


### PR DESCRIPTION
## Summary
- Update the release workflow from actions/download-artifact@v4 to actions/download-artifact@v7

## Validation
- git diff --check
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"