### PR TITLE
Allow JavaFX native library loading on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,6 +310,7 @@ jobs:
           codesign --verify --deep --strict --verbose=4 "${app_image}"
           codesign -d --entitlements :- "${app_image}" 2>&1 | tee /tmp/fx2048-entitlements.plist
           grep -q 'com.apple.security.cs.allow-jit' /tmp/fx2048-entitlements.plist
+          grep -q 'com.apple.security.cs.disable-library-validation' /tmp/fx2048-entitlements.plist
 
           jpackage \
             --type dmg \

--- a/src/jpackage/fx2048.entitlements
+++ b/src/jpackage/fx2048.entitlements
@@ -6,5 +6,7 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add `com.apple.security.cs.disable-library-validation` to the macOS entitlements.
- Verify the signed app image includes the library-validation entitlement during release.

## Why
The v1.0.6 app starts the JVM but JavaFX fails to initialize because Prism native libraries are extracted to `~/.openjfx/cache` and macOS hardened runtime rejects them with:

```
mapping process and mapped file (non-platform) have different Team IDs
```

Disabling library validation for the signed app allows JavaFX to load its cached native libraries.

## Validation
- `plutil -lint src/jpackage/fx2048.entitlements`
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"`
- `./mvnw test`
