### PR TITLE
Keep board chrome stable across grid sizes

### DIFF
--- a/src/main/java/io/fxgame/game2048/AboutContent.java
+++ b/src/main/java/io/fxgame/game2048/AboutContent.java
@@ -17,17 +17,13 @@ final class AboutContent extends TextFlow {
         setPrefSize(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
 
         getChildren().setAll(
-                styledText("2048", "game-lblAbout"),
-                styledText("FX", "game-lblAbout2"),
-                styledText(" Game\n", "game-lblAbout"),
                 styledText("JavaFX game - Desktop version\n\n", "game-lblAboutSub"),
-                styledText("Powered by ", "game-lblAboutSub"),
-                aboutLink("OpenJFX", "https://openjfx.io/"),
-                styledText(" Project \n\n", "game-lblAboutSub"),
-                styledText("© ", "game-lblAboutSub"),
-                aboutLink("@JPeredaDnr", "https://twitter.com/JPeredaDnr"),
-                styledText(" & ", "game-lblAboutSub"),
-                aboutLink("@brunoborges", "https://twitter.com/brunoborges"),
+                styledText("Creator and maintainer: ", "game-lblAboutSub"),
+                aboutLink("@brunoborges", "https://github.com/brunoborges"),
+                styledText("\nContributor: ", "game-lblAboutSub"),
+                aboutLink("JPereda", "https://github.com/JPeredaDnr"),
+                styledText("\nProject site: ", "game-lblAboutSub"),
+                aboutLink("brunoborges.github.io/fx2048", "https://brunoborges.github.io/fx2048/"),
                 styledText("\n\n", "game-lblAboutSub"),
                 styledText("Version " + Game2048.VERSION + "\n\n", "game-lblAboutSub"));
     }

--- a/src/main/java/io/fxgame/game2048/Board.java
+++ b/src/main/java/io/fxgame/game2048/Board.java
@@ -56,12 +56,12 @@ public class Board extends Pane {
     private final OverlayPanel overlayPanel;
 
     // Overlay Buttons
-    private final Button bTry = new Button("Try again");
-    private final Button bContinue = new Button("Keep going");
-    private final Button bContinueNo = new Button("No, keep going");
+    private final Button bTry = new Button("New Game");
+    private final Button bContinue = new Button("Continue");
+    private final Button bContinueNo = new Button("Cancel");
     private final Button bSave = new Button("Save");
     private final Button bRestore = new Button("Restore");
-    private final Button bApplySettings = new Button("Apply");
+    private final Button bApplySettings = new Button("Apply & Restart");
     private final Button bQuit = new Button("Quit");
     private final ChoiceBox<Integer> gridSizeChoice = new ChoiceBox<>();
 

--- a/src/main/java/io/fxgame/game2048/Board.java
+++ b/src/main/java/io/fxgame/game2048/Board.java
@@ -23,6 +23,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
+import javafx.scene.transform.Scale;
 import javafx.util.Duration;
 
 /**
@@ -36,6 +37,7 @@ public class Board extends Pane {
     private static final int TOP_HEIGHT = 92;
     private static final int GAP_HEIGHT = 50;
     private static final int TOOLBAR_HEIGHT = 80;
+    private static final int GRID_DIMENSION = CELL_SIZE * GridOperator.DEFAULT_GRID_SIZE + BORDER_WIDTH * 2;
 
     private final GameState state = new GameState();
 
@@ -67,7 +69,8 @@ public class Board extends Pane {
 
     private final Label lblTime = new Label();
 
-    private final int gridDimension;
+    private final int gridDimension = GRID_DIMENSION;
+    private final double gridScale;
     private final GridOperator gridOperator;
     private final SessionManager sessionManager;
     private final IntConsumer gridSizeChangeHandler;
@@ -80,7 +83,7 @@ public class Board extends Pane {
     public Board(GridOperator grid, IntConsumer gridSizeChangeHandler) {
         this.gridOperator = grid;
         this.gridSizeChangeHandler = gridSizeChangeHandler;
-        gridDimension = layoutWidthForGridSize(grid.getGridSize());
+        gridScale = calculateGridScale(grid.getGridSize());
         overlayPanel = new OverlayPanel(gridDimension, TOP_HEIGHT, GAP_HEIGHT);
         sessionManager = new SessionManager(gridOperator);
 
@@ -90,12 +93,16 @@ public class Board extends Pane {
         initGameProperties();
     }
 
-    static int layoutWidthForGridSize(int gridSize) {
-        return CELL_SIZE * gridSize + BORDER_WIDTH * 2;
+    static int layoutWidth() {
+        return GRID_DIMENSION;
     }
 
-    static int layoutHeightForGridSize(int gridSize) {
-        return TOP_HEIGHT + GAP_HEIGHT + layoutWidthForGridSize(gridSize) + TOOLBAR_HEIGHT * 2;
+    static int layoutHeight() {
+        return TOP_HEIGHT + GAP_HEIGHT + GRID_DIMENSION + TOOLBAR_HEIGHT * 2;
+    }
+
+    static double calculateGridScale(int gridSize) {
+        return (double) GridOperator.DEFAULT_GRID_SIZE / gridSize;
     }
 
     private void createScore() {
@@ -190,6 +197,7 @@ public class Board extends Pane {
         });
 
         gridGroup.getStyleClass().add("game-grid");
+        gridGroup.getTransforms().setAll(new Scale(gridScale, gridScale, 0, 0));
         gridGroup.setManaged(false);
         gridGroup.setLayoutX(BORDER_WIDTH);
         gridGroup.setLayoutY(BORDER_WIDTH);

--- a/src/main/java/io/fxgame/game2048/Game2048.java
+++ b/src/main/java/io/fxgame/game2048/Game2048.java
@@ -16,6 +16,8 @@ import java.util.Objects;
 public class Game2048 extends Application {
 
     public static final String VERSION = AppMetadata.VERSION;
+    private static final double MIN_WINDOW_WIDTH = 360;
+    private static final double MIN_WINDOW_HEIGHT = 480;
     private static Game2048 applicationInstance;
     private GamePane gamePane;
 
@@ -66,8 +68,8 @@ public class Game2048 extends Application {
                 visualBounds.getHeight() / (gameBounds.getHeight() + margin));
         primaryStage.setTitle("2048FX " + VERSION);
         primaryStage.setScene(scene);
-        primaryStage.setMinWidth(gameBounds.getWidth() / 2d);
-        primaryStage.setMinHeight(gameBounds.getHeight() / 2d);
+        primaryStage.setMinWidth(MIN_WINDOW_WIDTH);
+        primaryStage.setMinHeight(MIN_WINDOW_HEIGHT);
         primaryStage.setWidth(((gameBounds.getWidth() + margin) * factor) / 1.5d);
         primaryStage.setHeight(((gameBounds.getHeight() + margin) * factor) / 1.5d);
     }

--- a/src/main/java/io/fxgame/game2048/GamePane.java
+++ b/src/main/java/io/fxgame/game2048/GamePane.java
@@ -19,8 +19,6 @@ import static io.fxgame.game2048.Direction.*;
 public class GamePane extends StackPane {
 
     private static final double STATUS_BAR_HEIGHT = 20;
-    private static final double REFERENCE_GAME_WIDTH = Board.layoutWidthForGridSize(GridOperator.DEFAULT_GRID_SIZE);
-    private static final double REFERENCE_GAME_HEIGHT = Board.layoutHeightForGridSize(GridOperator.DEFAULT_GRID_SIZE);
 
     private GameManager gameManager;
     private Bounds gameBounds;
@@ -87,9 +85,7 @@ public class GamePane extends StackPane {
                 availableWidth,
                 availableHeight,
                 gameBounds.getWidth(),
-                gameBounds.getHeight(),
-                REFERENCE_GAME_WIDTH,
-                REFERENCE_GAME_HEIGHT);
+                gameBounds.getHeight());
         gameManager.setScale(scale);
         gameManager.setLayoutX((getWidth() - gameBounds.getWidth()) / 2d);
         gameManager.setLayoutY((getHeight() - STATUS_BAR_HEIGHT - gameBounds.getHeight()) / 2d);
@@ -99,12 +95,8 @@ public class GamePane extends StackPane {
             double availableWidth,
             double availableHeight,
             double gameWidth,
-            double gameHeight,
-            double referenceWidth,
-            double referenceHeight) {
-        var currentGridScale = Math.min(availableWidth / gameWidth, availableHeight / gameHeight);
-        var referenceGridScale = Math.min(availableWidth / referenceWidth, availableHeight / referenceHeight);
-        return Math.min(currentGridScale, referenceGridScale);
+            double gameHeight) {
+        return Math.min(availableWidth / gameWidth, availableHeight / gameHeight);
     }
 
     private final BooleanProperty cmdCtrlKeyPressed = new SimpleBooleanProperty(false);

--- a/src/test/java/io/fxgame/game2048/GamePaneTest.java
+++ b/src/test/java/io/fxgame/game2048/GamePaneTest.java
@@ -7,42 +7,25 @@ import org.junit.jupiter.api.Test;
 class GamePaneTest {
 
     @Test
-    void smallerGridsDoNotScaleGameChromeAboveDefaultGridScale() {
+    void calculatesScaleFromAvailableSpaceAndStableGameBounds() {
         var availableWidth = 1200.0;
         var availableHeight = 900.0;
-        var fourByFourWidth = Board.layoutWidthForGridSize(4);
-        var fourByFourHeight = Board.layoutHeightForGridSize(4);
-        var defaultWidth = Board.layoutWidthForGridSize(GridOperator.DEFAULT_GRID_SIZE);
-        var defaultHeight = Board.layoutHeightForGridSize(GridOperator.DEFAULT_GRID_SIZE);
 
         var scale = GamePane.calculateGameScale(
                 availableWidth,
                 availableHeight,
-                fourByFourWidth,
-                fourByFourHeight,
-                defaultWidth,
-                defaultHeight);
+                Board.layoutWidth(),
+                Board.layoutHeight());
 
-        assertEquals(Math.min(availableWidth / defaultWidth, availableHeight / defaultHeight), scale);
+        assertEquals(Math.min(availableWidth / Board.layoutWidth(), availableHeight / Board.layoutHeight()), scale);
     }
 
     @Test
-    void largerGridsStillScaleDownToFit() {
-        var availableWidth = 1200.0;
-        var availableHeight = 900.0;
-        var largeGridWidth = Board.layoutWidthForGridSize(8);
-        var largeGridHeight = Board.layoutHeightForGridSize(8);
-        var defaultWidth = Board.layoutWidthForGridSize(GridOperator.DEFAULT_GRID_SIZE);
-        var defaultHeight = Board.layoutHeightForGridSize(GridOperator.DEFAULT_GRID_SIZE);
-
-        var scale = GamePane.calculateGameScale(
-                availableWidth,
-                availableHeight,
-                largeGridWidth,
-                largeGridHeight,
-                defaultWidth,
-                defaultHeight);
-
-        assertEquals(Math.min(availableWidth / largeGridWidth, availableHeight / largeGridHeight), scale);
+    void boardDimensionsStayStableAcrossGridSizes() {
+        assertEquals(784, Board.layoutWidth());
+        assertEquals(1086, Board.layoutHeight());
+        assertEquals(1.5, Board.calculateGridScale(4));
+        assertEquals(1.0, Board.calculateGridScale(GridOperator.DEFAULT_GRID_SIZE));
+        assertEquals(0.375, Board.calculateGridScale(16));
     }
 }


### PR DESCRIPTION
## Summary\n- keep the board chrome and playfield dimensions stable across grid size changes\n- scale grid contents internally so 4x4 and larger boards adapt via cell size instead of resizing the app chrome\n- lower the stage minimum size so the window is not constrained by the game bounds\n- update scale tests for the stable board dimensions\n\n## Validation\n- ./mvnw --batch-mode --no-transfer-progress test