### PR TITLE
Refactor settings overlay for pluggable settings

### DIFF
--- a/src/main/java/io/fxgame/game2048/Board.java
+++ b/src/main/java/io/fxgame/game2048/Board.java
@@ -1,9 +1,9 @@
 package io.fxgame.game2048;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.IntConsumer;
-import java.util.stream.IntStream;
 
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
@@ -16,7 +16,6 @@ import javafx.beans.value.ObservableValue;
 import javafx.geometry.Pos;
 import javafx.scene.Group;
 import javafx.scene.control.Button;
-import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
@@ -63,9 +62,8 @@ public class Board extends Pane {
     private final Button bContinueNo = new Button("Cancel");
     private final Button bSave = new Button("Save");
     private final Button bRestore = new Button("Restore");
-    private final Button bApplySettings = new Button("Apply & Restart");
+    private final Button bApplySettings = new Button("Apply");
     private final Button bQuit = new Button("Quit");
-    private final ChoiceBox<Integer> gridSizeChoice = new ChoiceBox<>();
 
     private final HBox hToolbar = new HBox();
 
@@ -76,6 +74,7 @@ public class Board extends Pane {
     private final GridOperator gridOperator;
     private final SessionManager sessionManager;
     private final IntConsumer gridSizeChangeHandler;
+    private final SettingsPanel settingsPanel;
 
     public Board(GridOperator grid) {
         this(grid, _ -> {
@@ -88,6 +87,7 @@ public class Board extends Pane {
         gridScale = calculateGridScale(grid.getGridSize());
         overlayPanel = new OverlayPanel(gridDimension, TOP_HEIGHT, GAP_HEIGHT);
         sessionManager = new SessionManager(gridOperator);
+        settingsPanel = new SettingsPanel(List.of(new GridSizeSetting(gridOperator, gridSizeChangeHandler)));
 
         createScore();
         createGrid();
@@ -273,12 +273,8 @@ public class Board extends Pane {
     }
 
     private void applySettings() {
-        var selectedGridSize = gridSizeChoice.getValue();
-        UserSettings.LOCAL.setGridSize(selectedGridSize);
-
-        if (selectedGridSize != gridOperator.getGridSize()) {
-            gridSizeChangeHandler.accept(selectedGridSize);
-        } else {
+        var startsNewGame = settingsPanel.apply();
+        if (!startsNewGame) {
             keepGoing();
         }
     }
@@ -355,13 +351,6 @@ public class Board extends Pane {
 
         bQuit.getStyleClass().add("game-button");
         bQuit.setOnAction(_ -> exitGame());
-
-        gridSizeChoice.getItems().setAll(IntStream
-                .rangeClosed(GridOperator.MIN_GRID_SIZE, GridOperator.MAX_GRID_SIZE)
-                .boxed()
-                .toList());
-        gridSizeChoice.setValue(gridOperator.getGridSize());
-        gridSizeChoice.getStyleClass().add("game-settings-choice");
 
         state.gameWonProperty.addListener(wonListener);
         state.gameOverProperty
@@ -551,22 +540,8 @@ public class Board extends Pane {
 
     private void showSettingsOverlay() {
         gameTimer.pause();
-
-        var title = new Label("Settings");
-        title.getStyleClass().setAll("game-label", "game-lblPause");
-
-        var warning = new Label("Changing grid size starts a new game");
-        warning.getStyleClass().setAll("game-label", "game-lblWarning");
-
-        var gridSizeLabel = new Label("Grid size");
-        gridSizeLabel.getStyleClass().setAll("game-label", "game-settings-label");
-        gridSizeChoice.setValue(gridOperator.getGridSize());
-
-        var gridSizeRow = new HBox(15, gridSizeLabel, gridSizeChoice);
-        gridSizeRow.setAlignment(Pos.CENTER);
-        gridSizeRow.getStyleClass().add("game-settings-row");
-
-        overlayPanel.showContent("game-overlay-pause", bApplySettings, bContinueNo, title, warning, gridSizeRow);
+        settingsPanel.refresh();
+        overlayPanel.showContent("game-overlay-pause", bApplySettings, bContinueNo, settingsPanel);
         showOverlay(bApplySettings);
     }
 

--- a/src/main/java/io/fxgame/game2048/GridSizeSetting.java
+++ b/src/main/java/io/fxgame/game2048/GridSizeSetting.java
@@ -1,0 +1,58 @@
+package io.fxgame.game2048;
+
+import java.util.Optional;
+import java.util.function.IntConsumer;
+import java.util.stream.IntStream;
+
+import javafx.scene.Node;
+import javafx.scene.control.ChoiceBox;
+
+final class GridSizeSetting implements SettingsPanel.Item {
+
+    private final GridOperator gridOperator;
+    private final IntConsumer gridSizeChangeHandler;
+    private final ChoiceBox<Integer> gridSizeChoice = new ChoiceBox<>();
+
+    GridSizeSetting(GridOperator gridOperator, IntConsumer gridSizeChangeHandler) {
+        this.gridOperator = gridOperator;
+        this.gridSizeChangeHandler = gridSizeChangeHandler;
+
+        gridSizeChoice.getItems().setAll(IntStream
+                .rangeClosed(GridOperator.MIN_GRID_SIZE, GridOperator.MAX_GRID_SIZE)
+                .boxed()
+                .toList());
+        gridSizeChoice.getStyleClass().add("game-settings-choice");
+    }
+
+    @Override
+    public String label() {
+        return "Grid size";
+    }
+
+    @Override
+    public Node control() {
+        return gridSizeChoice;
+    }
+
+    @Override
+    public Optional<String> warning() {
+        return Optional.of("Changing grid size starts a new game");
+    }
+
+    @Override
+    public void refresh() {
+        gridSizeChoice.setValue(gridOperator.getGridSize());
+    }
+
+    @Override
+    public boolean apply() {
+        var selectedGridSize = gridSizeChoice.getValue();
+        UserSettings.LOCAL.setGridSize(selectedGridSize);
+
+        if (selectedGridSize != gridOperator.getGridSize()) {
+            gridSizeChangeHandler.accept(selectedGridSize);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/io/fxgame/game2048/SettingsPanel.java
+++ b/src/main/java/io/fxgame/game2048/SettingsPanel.java
@@ -3,10 +3,12 @@ package io.fxgame.game2048;
 import java.util.List;
 import java.util.Optional;
 
+import javafx.geometry.HPos;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
-import javafx.scene.layout.HBox;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
 
 final class SettingsPanel extends VBox {
@@ -20,12 +22,13 @@ final class SettingsPanel extends VBox {
         var title = new Label("Settings");
         title.getStyleClass().setAll("game-label", "game-lblPause");
 
-        var settingsList = new VBox(8);
+        var settingsList = new GridPane();
         settingsList.setAlignment(Pos.CENTER);
+        settingsList.setHgap(15);
+        settingsList.setVgap(8);
         settingsList.getStyleClass().add("game-settings-list");
-        settingsList.getChildren().setAll(this.items.stream()
-                .map(this::createSettingNode)
-                .toList());
+        settingsList.getColumnConstraints().setAll(labelColumn(), controlColumn());
+        addSettingRows(settingsList);
 
         setAlignment(Pos.CENTER);
         getStyleClass().add("game-settings-panel");
@@ -46,25 +49,35 @@ final class SettingsPanel extends VBox {
         return startsNewGame;
     }
 
-    private Node createSettingNode(Item item) {
-        var label = new Label(item.label());
-        label.getStyleClass().setAll("game-label", "game-settings-label");
+    private void addSettingRows(GridPane settingsList) {
+        var rowIndex = 0;
+        for (var item : items) {
+            var warning = item.warning();
+            if (warning.isPresent()) {
+                var warningLabel = new Label(warning.get());
+                warningLabel.getStyleClass().setAll("game-label", "game-lblWarning");
+                GridPane.setColumnSpan(warningLabel, 2);
+                GridPane.setHalignment(warningLabel, HPos.CENTER);
+                settingsList.add(warningLabel, 0, rowIndex++);
+            }
 
-        var row = new HBox(15, label, item.control());
-        row.setAlignment(Pos.CENTER);
-        row.getStyleClass().add("game-settings-row");
-
-        var warning = item.warning();
-        if (warning.isEmpty()) {
-            return row;
+            var label = new Label(item.label());
+            label.getStyleClass().setAll("game-label", "game-settings-label");
+            settingsList.add(label, 0, rowIndex);
+            settingsList.add(item.control(), 1, rowIndex++);
         }
+    }
 
-        var warningLabel = new Label(warning.get());
-        warningLabel.getStyleClass().setAll("game-label", "game-lblWarning");
+    private ColumnConstraints labelColumn() {
+        var column = new ColumnConstraints();
+        column.setHalignment(HPos.RIGHT);
+        return column;
+    }
 
-        var setting = new VBox(4, warningLabel, row);
-        setting.setAlignment(Pos.CENTER);
-        return setting;
+    private ColumnConstraints controlColumn() {
+        var column = new ColumnConstraints();
+        column.setHalignment(HPos.LEFT);
+        return column;
     }
 
     interface Item {

--- a/src/main/java/io/fxgame/game2048/SettingsPanel.java
+++ b/src/main/java/io/fxgame/game2048/SettingsPanel.java
@@ -1,0 +1,83 @@
+package io.fxgame.game2048;
+
+import java.util.List;
+import java.util.Optional;
+
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+
+final class SettingsPanel extends VBox {
+
+    private final List<Item> items;
+
+    SettingsPanel(List<Item> items) {
+        super(10);
+        this.items = List.copyOf(items);
+
+        var title = new Label("Settings");
+        title.getStyleClass().setAll("game-label", "game-lblPause");
+
+        var settingsList = new VBox(8);
+        settingsList.setAlignment(Pos.CENTER);
+        settingsList.getStyleClass().add("game-settings-list");
+        settingsList.getChildren().setAll(this.items.stream()
+                .map(this::createSettingNode)
+                .toList());
+
+        setAlignment(Pos.CENTER);
+        getStyleClass().add("game-settings-panel");
+        getChildren().setAll(title, settingsList);
+    }
+
+    void refresh() {
+        items.forEach(Item::refresh);
+    }
+
+    boolean apply() {
+        var startsNewGame = false;
+        for (var item : items) {
+            if (item.apply()) {
+                startsNewGame = true;
+            }
+        }
+        return startsNewGame;
+    }
+
+    private Node createSettingNode(Item item) {
+        var label = new Label(item.label());
+        label.getStyleClass().setAll("game-label", "game-settings-label");
+
+        var row = new HBox(15, label, item.control());
+        row.setAlignment(Pos.CENTER);
+        row.getStyleClass().add("game-settings-row");
+
+        var warning = item.warning();
+        if (warning.isEmpty()) {
+            return row;
+        }
+
+        var warningLabel = new Label(warning.get());
+        warningLabel.getStyleClass().setAll("game-label", "game-lblWarning");
+
+        var setting = new VBox(4, warningLabel, row);
+        setting.setAlignment(Pos.CENTER);
+        return setting;
+    }
+
+    interface Item {
+        String label();
+
+        Node control();
+
+        default Optional<String> warning() {
+            return Optional.empty();
+        }
+
+        void refresh();
+
+        boolean apply();
+    }
+}

--- a/src/main/resources/io/fxgame/game2048/game.css
+++ b/src/main/resources/io/fxgame/game2048/game.css
@@ -162,12 +162,6 @@
 .game-settings-panel {
     -fx-spacing: 10;
 }
-.game-settings-list {
-    -fx-spacing: 8;
-}
-.game-settings-row {
-    -fx-padding: 20 0 10 0;
-}
 .game-settings-label {
     -fx-font-size: 28px;
     -fx-text-fill: #776e65;

--- a/src/main/resources/io/fxgame/game2048/game.css
+++ b/src/main/resources/io/fxgame/game2048/game.css
@@ -159,6 +159,12 @@
     -fx-border-color: -fx-focus-color;
     -fx-border-width: 0.5px;
 }
+.game-settings-panel {
+    -fx-spacing: 10;
+}
+.game-settings-list {
+    -fx-spacing: 8;
+}
 .game-settings-row {
     -fx-padding: 20 0 10 0;
 }


### PR DESCRIPTION
## Summary
- Extract settings overlay rendering into a reusable SettingsPanel with pluggable items
- Move existing grid size behavior into GridSizeSetting
- Use a two-column layout so future labels and controls stay aligned

## Notes
This does not implement animation speed, auto-save, or best scores; it prepares the panel for those follow-up settings.

## Validation
- ./mvnw --batch-mode --no-transfer-progress test
- ./mvnw --batch-mode --no-transfer-progress clean package