### PR TITLE
Fast-forward move animations on rapid input

### DIFF
--- a/src/main/java/io/fxgame/game2048/AnimationSpeed.java
+++ b/src/main/java/io/fxgame/game2048/AnimationSpeed.java
@@ -22,6 +22,10 @@ enum AnimationSpeed {
         return multiplier == 0.0 ? Duration.ZERO : duration.multiply(multiplier);
     }
 
+    boolean isInstant() {
+        return multiplier == 0.0;
+    }
+
     @Override
     public String toString() {
         return label;

--- a/src/main/java/io/fxgame/game2048/Board.java
+++ b/src/main/java/io/fxgame/game2048/Board.java
@@ -426,6 +426,11 @@ public class Board extends Pane {
             return;
         }
 
+        if (animationsDisabled()) {
+            lblPoints.setOpacity(0);
+            return;
+        }
+
         final var timeline = new Timeline();
         lblPoints.setText("+" + state.gameMovePoints.getValue().toString());
         lblPoints.setOpacity(1);
@@ -452,6 +457,10 @@ public class Board extends Pane {
         return animationSpeed.scale(baseDuration);
     }
 
+    boolean animationsDisabled() {
+        return animationSpeed.isInstant();
+    }
+
     private void setAnimationSpeed(AnimationSpeed animationSpeed) {
         this.animationSpeed = animationSpeed;
     }
@@ -459,6 +468,11 @@ public class Board extends Pane {
     public void addTile(Tile tile) {
         positionTile(tile);
         gridGroup.getChildren().add(tile);
+    }
+
+    void moveTileImmediately(Tile tile, Location location) {
+        tile.setLocation(location);
+        positionTile(tile);
     }
 
     public void clearTiles() {

--- a/src/main/java/io/fxgame/game2048/GameManager.java
+++ b/src/main/java/io/fxgame/game2048/GameManager.java
@@ -41,6 +41,7 @@ public class GameManager extends Group {
     private final UndoManager undoManager = new UndoManager();
     private final BooleanProperty undoAvailable = new SimpleBooleanProperty(false);
     private Animation shakingAnimation;
+    private ParallelTransition activeTileMovement;
     private MoveSnapshot undoSnapshot;
     private boolean shakingAnimationPlaying = false;
     private boolean shakingXYState = false;
@@ -140,10 +141,8 @@ public class GameManager extends Group {
      * @param direction is the selected direction to move the tiles
      */
     private void moveTiles(Direction direction) {
-        synchronized (gameGrid) {
-            if (movingTiles) {
-                return;
-            }
+        if (isMovingTiles() && !finishActiveTileMovement()) {
+            return;
         }
 
         board.setPoints(0);
@@ -168,30 +167,51 @@ public class GameManager extends Group {
         }
 
         board.animateScore();
-        if (!parallelTransition.getChildren().isEmpty()) {
-            parallelTransition.setOnFinished(_ -> {
-                board.removeTiles(mergedToBeRemoved);
-                gameGrid.values().stream().filter(Objects::nonNull).forEach(Tile::clearMerge);
-                setMovingTiles(false);
+        if (moveResult.tilesMoved()) {
+            if (parallelTransition.getChildren().isEmpty()) {
+                finishMoveAfterTileMotion(false);
+            } else {
+                parallelTransition.setOnFinished(_ -> finishMoveAfterTileMotion(true));
 
-                var addedTile = model.addRandomTile();
-                if (addedTile.isPresent()) {
-                    addAndAnimateRandomTile(addedTile.get());
-                } else if (!model.hasMergeMovements()) {
-                    board.setGameOver(true);
-                }
-
-                if (UserSettings.LOCAL.getAutoSave() == AutoSaveMode.AFTER_EVERY_MOVE) {
-                    doAutoSaveSession();
-                }
-            });
-
-            setMovingTiles(true);
-            parallelTransition.play();
+                activeTileMovement = parallelTransition;
+                setMovingTiles(true);
+                parallelTransition.play();
+            }
         }
 
         if (!moveResult.tilesMoved()) {
             shakeGamePane();
+        }
+    }
+
+    private boolean finishActiveTileMovement() {
+        var tileMovement = activeTileMovement;
+        if (tileMovement == null) {
+            return false;
+        }
+
+        tileMovement.setOnFinished(null);
+        tileMovement.jumpTo(tileMovement.getTotalDuration());
+        tileMovement.stop();
+        finishMoveAfterTileMotion(false);
+        return true;
+    }
+
+    private void finishMoveAfterTileMotion(boolean animateAddedTile) {
+        activeTileMovement = null;
+        board.removeTiles(mergedToBeRemoved);
+        gameGrid.values().stream().filter(Objects::nonNull).forEach(Tile::clearMerge);
+        setMovingTiles(false);
+
+        var addedTile = model.addRandomTile();
+        if (addedTile.isPresent()) {
+            addRandomTileToBoard(addedTile.get(), animateAddedTile);
+        } else if (!model.hasMergeMovements()) {
+            board.setGameOver(true);
+        }
+
+        if (UserSettings.LOCAL.getAutoSave() == AutoSaveMode.AFTER_EVERY_MOVE) {
+            doAutoSaveSession();
         }
     }
 
@@ -205,14 +225,24 @@ public class GameManager extends Group {
                 gameGrid.put(movement.destination(), targetTile);
                 gameGrid.replace(movement.source(), null);
 
-                parallelTransition.getChildren().add(animateExistingTile(tile, targetTile.getLocation()));
-                parallelTransition.getChildren().add(animateMergedTile(targetTile));
+                if (board.animationsDisabled()) {
+                    board.moveTileImmediately(tile, targetTile.getLocation());
+                    targetTile.setScaleX(1.0);
+                    targetTile.setScaleY(1.0);
+                } else {
+                    parallelTransition.getChildren().add(animateExistingTile(tile, targetTile.getLocation()));
+                    parallelTransition.getChildren().add(animateMergedTile(targetTile));
+                }
                 mergedToBeRemoved.add(tile);
             } else {
-                parallelTransition.getChildren().add(animateExistingTile(tile, movement.destination()));
                 gameGrid.put(movement.destination(), tile);
                 gameGrid.replace(movement.source(), null);
-                tile.setLocation(movement.destination());
+                if (board.animationsDisabled()) {
+                    board.moveTileImmediately(tile, movement.destination());
+                } else {
+                    parallelTransition.getChildren().add(animateExistingTile(tile, movement.destination()));
+                    tile.setLocation(movement.destination());
+                }
             }
         });
     }
@@ -262,13 +292,28 @@ public class GameManager extends Group {
         updateUndoAvailability();
     }
 
+    private boolean isMovingTiles() {
+        synchronized (gameGrid) {
+            return movingTiles;
+        }
+    }
+
     private void updateUndoAvailability() {
         undoAvailable.set(undoSnapshot != null && !movingTiles);
     }
 
-    private void addAndAnimateRandomTile(GameModel.TileState tileState) {
+    private void addRandomTileToBoard(GameModel.TileState tileState, boolean animate) {
         var tile = board.addAnimatedTile(tileState.location(), tileState.value());
         gameGrid.put(tile.getLocation(), tile);
+
+        if (!animate || board.animationsDisabled()) {
+            tile.setScaleX(1.0);
+            tile.setScaleY(1.0);
+            if (model.isFull() && !model.hasMergeMovements()) {
+                board.setGameOver(true);
+            }
+            return;
+        }
 
         animateNewlyAddedTile(tile).play();
     }

--- a/src/test/java/io/fxgame/game2048/AnimationSpeedTest.java
+++ b/src/test/java/io/fxgame/game2048/AnimationSpeedTest.java
@@ -1,6 +1,8 @@
 package io.fxgame.game2048;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,5 +28,13 @@ class AnimationSpeedTest {
     @Test
     void offUsesInstantDuration() {
         assertEquals(Duration.ZERO, AnimationSpeed.OFF.scale(Duration.millis(100)));
+    }
+
+    @Test
+    void onlyOffDisablesAnimations() {
+        assertFalse(AnimationSpeed.SLOW.isInstant());
+        assertFalse(AnimationSpeed.NORMAL.isInstant());
+        assertFalse(AnimationSpeed.FAST.isInstant());
+        assertTrue(AnimationSpeed.OFF.isInstant());
     }
 }


### PR DESCRIPTION
## Summary
- fast-forward active tile movement when a new direction arrives during animation
- avoid zero-duration JavaFX transitions for Off / instant animation speed
- keep random tile insertion and move completion ordered before the next move

## Validation
- ./mvnw --batch-mode --no-transfer-progress test
- ./mvnw --batch-mode --no-transfer-progress clean package