### PR TITLE
Enable JPro for macOS arm64 and Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,6 +282,7 @@ jobs:
 
           runtime_max_heap="$(./mvnw --batch-mode --no-transfer-progress help:evaluate -Dexpression=runtime.max.heap -q -DforceStdout)"
           runtime_garbage_collector="$(./mvnw --batch-mode --no-transfer-progress help:evaluate -Dexpression=runtime.garbage.collector -q -DforceStdout)"
+          runtime_native_access="$(./mvnw --batch-mode --no-transfer-progress help:evaluate -Dexpression=runtime.native.access -q -DforceStdout)"
           app_image_dir="target/app-image"
           app_image="${app_image_dir}/fx2048.app"
 
@@ -300,6 +301,7 @@ jobs:
             --java-options -Dfile.encoding=UTF-8 \
             --java-options "${runtime_max_heap}" \
             --java-options "${runtime_garbage_collector}" \
+            --java-options "${runtime_native_access}" \
             --mac-package-identifier fx2048 \
             --mac-package-name fx2048 \
             --icon src/main/resources/io/fxgame/game2048/fx2048-logo.icns \

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ fx2048.iml
 .DS_Store
 .idea/workspace.xml
 target
+logs/
+RUNNING_PID

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
--Djavafx.platform=win

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ JPro support is available through the Maven `jpro` profile for:
 
 Windows is intentionally not supported in this JPro setup.
 
+JPro runs the JavaFX application on the server and streams the UI to a browser.
+This path does not use the desktop `AppLauncher`, `jlink`, or `jpackage` launchers.
+Instead, the `jpro` profile points JPro directly at `io.fxgame.game2048.Game2048`,
+the class that extends `javafx.application.Application`, and combines it with a
+platform profile that selects the JPro-compatible JavaFX native artifacts.
+
 Start JPro in development mode:
 
 ```bash
@@ -73,6 +79,13 @@ Start JPro in background/server mode:
 Then open:
 
 `http://localhost:8080/index.html`
+
+The `jpro:restart` goal writes the server PID to `RUNNING_PID`. Stop it with:
+
+```bash
+kill $(cat RUNNING_PID)
+rm -f RUNNING_PID
+```
 
 ### Create a GitHub release
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,26 @@ To create a native OS package, run:
 ./mvnw clean package javafx:jlink jpackage:jpackage
 ```
 
+### Run in a browser with JPro
+
+JPro support is available through the Maven `jpro` profile.
+
+Start JPro in development mode:
+
+```bash
+./mvnw -Pjpro jpro:run
+```
+
+Start JPro in background/server mode:
+
+```bash
+./mvnw -Pjpro jpro:restart
+```
+
+Then open:
+
+`http://localhost:8080/index.html`
+
 ### Create a GitHub release
 
 Run the [Release workflow](https://github.com/brunoborges/fx2048/actions/workflows/release.yml) manually from `main` to publish a new version. If `pom.xml` is at `1.0.2-SNAPSHOT`, the workflow prepares and tags `v1.0.2`, publishes the platform packages, and bumps `main` to `1.0.3-SNAPSHOT`.

--- a/README.md
+++ b/README.md
@@ -44,18 +44,30 @@ To create a native OS package, run:
 
 ### Run in a browser with JPro
 
-JPro support is available through the Maven `jpro` profile.
+JPro support is available through the Maven `jpro` profile for:
+
+- macOS arm64 (`jpro-macos-aarch64`)
+- Linux amd64 (`jpro-linux-amd64`)
+- Linux arm64 (`jpro-linux-aarch64`)
+
+Windows is intentionally not supported in this JPro setup.
 
 Start JPro in development mode:
 
 ```bash
-./mvnw -Pjpro jpro:run
+./mvnw -Pjpro,jpro-macos-aarch64 jpro:run
+# or:
+# ./mvnw -Pjpro,jpro-linux-amd64 jpro:run
+# ./mvnw -Pjpro,jpro-linux-aarch64 jpro:run
 ```
 
 Start JPro in background/server mode:
 
 ```bash
-./mvnw -Pjpro jpro:restart
+./mvnw -Pjpro,jpro-macos-aarch64 jpro:restart
+# or:
+# ./mvnw -Pjpro,jpro-linux-amd64 jpro:restart
+# ./mvnw -Pjpro,jpro-linux-aarch64 jpro:restart
 ```
 
 Then open:

--- a/docs/technology.html
+++ b/docs/technology.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="How fx2048 is built: Java, JavaFX, Maven, jlink, jpackage, runtime settings, package sizes, and source code stats.">
+  <meta name="description" content="How fx2048 is built: Java, JavaFX, Maven, jlink, jpackage, JPro browser deployment, runtime settings, package sizes, and source code stats.">
   <link rel="canonical" href="https://brunoborges.github.io/fx2048/technology.html">
   <meta property="og:site_name" content="fx2048">
   <meta property="og:type" content="article">
   <meta property="og:title" content="fx2048 Technology - JavaFX runtime, packaging, and memory">
-  <meta property="og:description" content="How fx2048 is built with JavaFX, Maven, jlink, jpackage, a tuned JVM profile, native installers, and runtime memory comparisons.">
+  <meta property="og:description" content="How fx2048 is built with JavaFX, Maven, jlink, jpackage, JPro browser deployment, a tuned JVM profile, native installers, and runtime memory comparisons.">
   <meta property="og:url" content="https://brunoborges.github.io/fx2048/technology.html">
   <meta property="og:image" content="https://brunoborges.github.io/fx2048/assets/screenshot.png">
   <meta property="og:image:width" content="1478">
@@ -16,7 +16,7 @@
   <meta property="og:image:alt" content="fx2048 desktop game screenshot showing a 2048 board.">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="fx2048 Technology - JavaFX runtime, packaging, and memory">
-  <meta name="twitter:description" content="How fx2048 is built with JavaFX, Maven, jlink, jpackage, a tuned JVM profile, native installers, and runtime memory comparisons.">
+  <meta name="twitter:description" content="How fx2048 is built with JavaFX, Maven, jlink, jpackage, JPro browser deployment, a tuned JVM profile, native installers, and runtime memory comparisons.">
   <meta name="twitter:image" content="https://brunoborges.github.io/fx2048/assets/screenshot.png">
   <meta name="twitter:image:alt" content="fx2048 desktop game screenshot showing a 2048 board.">
   <link rel="icon" href="assets/fx2048.png">
@@ -467,7 +467,7 @@
         <span class="eyebrow">Under the hood</span>
         <h1>How fx2048 is built and packaged.</h1>
         <p class="lede">
-          fx2048 is a small modular Java desktop app with a JavaFX UI, a custom runtime image, native installers, and a deliberately tight runtime footprint. Its recent modernization was planned, implemented, debugged, and documented with GitHub Copilot.
+          fx2048 is a small modular Java app with a JavaFX UI, a custom desktop runtime image, native installers, optional JPro browser deployment, and a deliberately tight runtime footprint. Its recent modernization was planned, implemented, debugged, and documented with GitHub Copilot.
         </p>
       </div>
 
@@ -524,7 +524,7 @@
       <section class="container" aria-labelledby="stack-heading">
         <div class="section-heading">
           <h2 id="stack-heading">Technology stack</h2>
-          <p>The app is intentionally simple: Java modules, JavaFX controls and animation APIs, Maven automation, and platform-native packages.</p>
+          <p>The app is intentionally simple: Java modules, JavaFX controls and animation APIs, Maven automation, platform-native packages, and an optional JPro browser runtime.</p>
         </div>
         <div class="grid">
           <article class="card">
@@ -542,6 +542,10 @@
           <article class="card">
             <h3>Build and packaging</h3>
             <p><a href="https://maven.apache.org/">Maven</a> builds the app, <a href="https://docs.oracle.com/en/java/javase/25/docs/specs/man/jlink.html"><code>jlink</code></a> creates a custom runtime, and <a href="https://docs.oracle.com/en/java/javase/25/docs/specs/man/jpackage.html"><code>jpackage</code></a> produces DMG, MSI, and DEB installers.</p>
+          </article>
+          <article class="card">
+            <h3>Browser deployment</h3>
+            <p><a href="https://www.jpro.one/">JPro</a> can run the JavaFX application on a server and stream the UI to a browser, using a separate Maven profile from the desktop packaging path.</p>
           </article>
         </div>
       </section>
@@ -578,15 +582,45 @@
                   <a href="https://maven.apache.org/plugins/maven-compiler-plugin/">Maven Compiler Plugin 3.15.0</a>,
                   <a href="https://github.com/openjfx/javafx-maven-plugin">JavaFX Maven Plugin 0.0.8</a>,
                   <a href="https://maven.apache.org/plugins/maven-jar-plugin/">Maven JAR Plugin 3.5.0</a>,
-                  and <a href="https://github.com/petr-panteleyev/jpackage-maven-plugin">jpackage Maven Plugin 1.7.4</a>.
+                  <a href="https://github.com/petr-panteleyev/jpackage-maven-plugin">jpackage Maven Plugin 1.7.4</a>,
+                  and <a href="https://www.jpro.one/">JPro Maven Plugin 2026.1.1</a>.
                 </td>
               </tr>
               <tr>
                 <td>Packaging</td>
                 <td><a href="https://docs.oracle.com/en/java/javase/25/docs/specs/man/jlink.html"><code>jlink</code></a> strips the runtime image, and <a href="https://docs.oracle.com/en/java/javase/25/docs/specs/man/jpackage.html"><code>jpackage</code></a> creates native installers from that runtime.</td>
               </tr>
+              <tr>
+                <td>Browser runtime</td>
+                <td>JPro serves the JavaFX application over HTTP from the Maven <code>jpro</code> profile, with platform profiles selecting JPro-compatible JavaFX native artifacts.</td>
+              </tr>
             </tbody>
           </table>
+        </div>
+      </section>
+
+      <section class="container" aria-labelledby="jpro-heading">
+        <div class="section-heading">
+          <h2 id="jpro-heading">JPro browser deployment model</h2>
+          <p>JPro is a separate runtime path for trying the JavaFX game in a browser without rewriting the UI in HTML and JavaScript.</p>
+        </div>
+        <div class="grid">
+          <article class="card">
+            <h3>Server-side JavaFX</h3>
+            <p>The JavaFX application runs in a JVM on the server. JPro exposes it at <code>http://localhost:8080/index.html</code> during local development and streams the UI to the browser.</p>
+          </article>
+          <article class="card">
+            <h3>Different entry point</h3>
+            <p>The desktop launcher uses <code>io.fxgame.game2048.AppLauncher</code>, but JPro is configured with <code>io.fxgame.game2048.Game2048</code> because JPro needs the class that directly extends <code>javafx.application.Application</code>.</p>
+          </article>
+          <article class="card">
+            <h3>Maven profiles</h3>
+            <p>Run JPro with the shared <code>jpro</code> profile plus one platform profile: <code>jpro-macos-aarch64</code>, <code>jpro-linux-amd64</code>, or <code>jpro-linux-aarch64</code>. Windows is not part of this JPro setup.</p>
+          </article>
+          <article class="card">
+            <h3>Lifecycle</h3>
+            <p><code>jpro:run</code> starts an attached development server. <code>jpro:restart</code> starts a background server and writes its process id to <code>RUNNING_PID</code>.</p>
+          </article>
         </div>
       </section>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <maven.compiler.release>25</maven.compiler.release>
         <javafx.version>26.0.1</javafx.version>
         <javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
+        <jpro.version>2026.1.1</jpro.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
         <main.class>io.fxgame.game2048.AppLauncher</main.class>
@@ -340,6 +341,41 @@
                         <configuration>
                             <type>DEB</type>
                             <icon>src/main/resources/io/fxgame/game2048/fx2048-logo.png</icon>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>jpro</id>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>jpro-sandec</id>
+                    <url>https://sandec.jfrog.io/artifactory/repo</url>
+                </pluginRepository>
+            </pluginRepositories>
+            <repositories>
+                <repository>
+                    <id>jpro-sandec</id>
+                    <url>https://sandec.jfrog.io/artifactory/repo</url>
+                </repository>
+            </repositories>
+            <dependencies>
+                <dependency>
+                    <groupId>one.jpro</groupId>
+                    <artifactId>jpro-webapi</artifactId>
+                    <version>${jpro.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>one.jpro</groupId>
+                        <artifactId>jpro-maven-plugin</artifactId>
+                        <version>${jpro.version}</version>
+                        <configuration>
+                            <mainClassName>${main.class}</mainClassName>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
         <main.class>io.fxgame.game2048.AppLauncher</main.class>
+        <jpro.main.class>io.fxgame.game2048.Game2048</jpro.main.class>
         <runtime.initial.heap>-Xms8m</runtime.initial.heap>
         <runtime.max.heap>-Xmx32m</runtime.max.heap>
         <runtime.thread.stack.size>-Xss512k</runtime.thread.stack.size>
@@ -32,6 +33,7 @@
         <runtime.garbage.collector>-XX:+UseG1GC</runtime.garbage.collector>
         <runtime.periodic.gc.interval>-XX:G1PeriodicGCInterval=10000</runtime.periodic.gc.interval>
         <runtime.periodic.gc.mode>-XX:+G1PeriodicGCInvokesConcurrent</runtime.periodic.gc.mode>
+        <runtime.native.access>--enable-native-access=javafx.graphics</runtime.native.access>
         <javafx.platform>win</javafx.platform>
     </properties>
 
@@ -135,6 +137,7 @@
                         <option>${runtime.garbage.collector}</option>
                         <option>${runtime.periodic.gc.interval}</option>
                         <option>${runtime.periodic.gc.mode}</option>
+                        <option>${runtime.native.access}</option>
                     </options>
                 </configuration>
             </plugin>
@@ -179,6 +182,7 @@
                         <option>${runtime.garbage.collector}</option>
                         <option>${runtime.periodic.gc.interval}</option>
                         <option>${runtime.periodic.gc.mode}</option>
+                        <option>${runtime.native.access}</option>
                     </javaOptions>
                     <linuxShortcut>true</linuxShortcut>
                     <linuxMenuGroup>Games</linuxMenuGroup>
@@ -209,6 +213,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <argLine>${runtime.native.access}</argLine>
+                </configuration>
             </plugin>
 
             <!-- Maven Enforcer Plugin -->
@@ -276,6 +283,19 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>mac-aarch64</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <javafx.platform>mac-aarch64</javafx.platform>
+            </properties>
         </profile>
 
         <profile>
@@ -375,7 +395,7 @@
                         <artifactId>jpro-maven-plugin</artifactId>
                         <version>${jpro.version}</version>
                         <configuration>
-                            <mainClassName>${main.class}</mainClassName>
+                            <mainClassName>${jpro.main.class}</mainClassName>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,27 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>jpro-macos-aarch64</id>
+            <properties>
+                <javafx.platform>mac-aarch64</javafx.platform>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>jpro-linux-amd64</id>
+            <properties>
+                <javafx.platform>linux</javafx.platform>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>jpro-linux-aarch64</id>
+            <properties>
+                <javafx.platform>linux-aarch64</javafx.platform>
+            </properties>
+        </profile>
     </profiles>
 
 </project>

--- a/src/main/java/io/fxgame/game2048/UserSettings.java
+++ b/src/main/java/io/fxgame/game2048/UserSettings.java
@@ -109,7 +109,7 @@ public enum UserSettings {
             return AnimationSpeed.valueOf(animationSpeed.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             Logger.getLogger(UserSettings.class.getName()).log(Level.WARNING,
-                    "Invalid animation speed setting. Using default animation speed.", e);
+                    "Invalid animation speed setting ''{0}''. Using default animation speed.", animationSpeed);
             return AnimationSpeed.DEFAULT;
         }
     }

--- a/src/test/java/io/fxgame/game2048/UserSettingsTest.java
+++ b/src/test/java/io/fxgame/game2048/UserSettingsTest.java
@@ -1,11 +1,19 @@
 package io.fxgame.game2048;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +47,10 @@ class UserSettingsTest {
 
         try {
             settings.store(invalidProperties, SETTINGS_FILENAME);
-            assertEquals(AnimationSpeed.DEFAULT, settings.getAnimationSpeed());
+            try (var logs = CapturingLogHandler.capture(Logger.getLogger(UserSettings.class.getName()))) {
+                assertEquals(AnimationSpeed.DEFAULT, settings.getAnimationSpeed());
+                assertTrue(logs.records().stream().anyMatch(record -> record.getLevel() == Level.WARNING));
+            }
         } finally {
             restoreOriginalSettings(settings, originalProperties, hadOriginalSettings);
         }
@@ -71,6 +82,51 @@ class UserSettingsTest {
         try {
             Files.deleteIfExists(Path.of(System.getProperty("user.home"), ".fx2048", SETTINGS_FILENAME));
         } catch (IOException ignored) {
+        }
+    }
+
+    private static final class CapturingLogHandler extends Handler implements AutoCloseable {
+        private final Logger logger;
+        private final Handler[] previousHandlers;
+        private final Level previousLevel;
+        private final boolean previousUseParentHandlers;
+        private final List<LogRecord> records = new ArrayList<>();
+
+        private CapturingLogHandler(Logger logger) {
+            this.logger = logger;
+            previousHandlers = logger.getHandlers();
+            previousLevel = logger.getLevel();
+            previousUseParentHandlers = logger.getUseParentHandlers();
+            Arrays.stream(previousHandlers).forEach(logger::removeHandler);
+            setLevel(Level.ALL);
+            logger.setUseParentHandlers(false);
+            logger.setLevel(Level.ALL);
+            logger.addHandler(this);
+        }
+
+        static CapturingLogHandler capture(Logger logger) {
+            return new CapturingLogHandler(logger);
+        }
+
+        List<LogRecord> records() {
+            return records;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+            logger.removeHandler(this);
+            Arrays.stream(previousHandlers).forEach(logger::addHandler);
+            logger.setLevel(previousLevel);
+            logger.setUseParentHandlers(previousUseParentHandlers);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `jpro` Maven profile with JPro plugin + repository wiring
- add explicit JPro platform profiles:
  - `jpro-macos-aarch64`
  - `jpro-linux-amd64`
  - `jpro-linux-aarch64`
- document profile-specific JPro run/restart commands in README
- explicitly scope this JPro setup to macOS arm64 and Linux (amd64/arm64); Windows is intentionally out of scope

## Validation
- `./mvnw '-Pjpro,jpro-macos-aarch64' -DskipTests compile`
- `./mvnw '-Pjpro,jpro-linux-amd64' -DskipTests compile`
- `./mvnw '-Pjpro,jpro-linux-aarch64' -DskipTests compile`
- `./mvnw -Pjpro help:describe '-Dplugin=one.jpro:jpro-maven-plugin' '-Dgoal=run'`
